### PR TITLE
Avoid warnings

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,14 +1,12 @@
-extern crate protoc_rust;
-
-use protoc_rust::Customize;
+use protoc_rust::{Codegen, Customize};
 
 fn main() {
    // Build our realtime feed structure
-   protoc_rust::run(protoc_rust::Args {
-      out_dir: "src/realtime",
-      input: &[ "src/realtime/data.proto" ],
-      includes: &[ "src" ],
-      customize: Customize { ..Default::default() },
-   })
-   .expect("protoc");
+   Codegen::new()
+      .out_dir("src/realtime")
+      .inputs(&["src/realtime/data.proto"])
+      .includes(&[ "src" ])
+      .customize(Customize { ..Default::default() })
+      .run()
+      .expect("protoc");
 }


### PR DESCRIPTION
I have made some changes to build.rs to avoid the deprecated warnings during build. Please consider to merge this changes into your master.