### PR TITLE
Move to protobuf_codegen_pure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,4 +34,4 @@ mockito = "0.25"
 tokio-test = "0.2"
 
 [build-dependencies]
-protoc-rust = "2"
+protobuf-codegen-pure = "2"

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,4 @@
-use protoc_rust::{ Codegen, Customize };
+use protobuf_codegen_pure::{ Codegen, Customize };
 
 fn main() {
    // Build our realtime feed structure
@@ -8,5 +8,5 @@ fn main() {
       .includes(&[ "src" ])
       .customize(Customize { ..Default::default() })
       .run()
-      .expect("protoc");
+      .expect("Codegen failed.");
 }


### PR DESCRIPTION
I have been poking at this crate for a little project I am writing to learn Rust and I hit an issue when trying to add the github repo as a dependency, since I do not have the protoc binary. I would prefer not to rely on it existing  on the system to keep my project buildable with just cargo and no external dependencies.