### PR TITLE
Add support for corporate action events

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,18 +20,18 @@ futures = "0.3"
 futures-util = { version = "0.3", default-features = false, features = [ "async-await", "sink", "std" ] }
 market-finance = "0.3"
 protobuf = "2"
-reqwest = "0.10"
+reqwest = "0.11.2"
 serde = { version = "1.0", features = [ "derive" ] }
 serde_json = "1.0"
 snafu = "0.6"
-tokio = { version = "0.2", default-features = false, features = [ "stream", "rt-threaded", "macros" ]}
-tokio-tungstenite = { version = "0.11", features = [ "tls" ] }
+tokio = { version = "1.3.0", default-features = false, features = [ "rt-multi-thread", "macros" ] }
+tokio-tungstenite = { version = "0.14.0", features = [ "rustls-tls" ] }
 url = "2.1"
 
 
 [dev-dependencies]
 mockito = "0.27"
-tokio-test = "0.2"
+tokio-test = "0.4.1"
 
 [build-dependencies]
 protobuf-codegen-pure = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ serde = { version = "1.0", features = [ "derive" ] }
 serde_json = "1.0"
 snafu = "0.6"
 tokio = { version = "1.3.0", default-features = false, features = [ "rt-multi-thread", "macros" ] }
-tokio-tungstenite = { version = "0.14.0", features = [ "rustls-tls" ] }
+tokio-tungstenite = { version = "0.21.0", features = [ "rustls-tls-native-roots" ] }
 url = "2.1"
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ futures = "0.3"
 futures-util = { version = "0.3", default-features = false, features = [ "async-await", "sink", "std" ] }
 market-finance = "0.3"
 protobuf = "2"
-reqwest = "0.11.2"
+reqwest = { version = "0.11.2", default-features = false, features = [ "rustls-tls" ] }
 serde = { version = "1.0", features = [ "derive" ] }
 serde_json = "1.0"
 snafu = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ chrono = { version = "0.4", features = [ "serde" ] }
 futures = "0.3"
 futures-util = { version = "0.3", default-features = false, features = [ "async-await", "sink", "std" ] }
 market-finance = "0.3"
-protobuf = "2"
+protobuf = "3"
 reqwest = { version = "0.11.2", default-features = false, features = [ "rustls-tls" ] }
 serde = { version = "1.0", features = [ "derive" ] }
 serde_json = "1.0"
@@ -34,4 +34,4 @@ mockito = "0.27"
 tokio-test = "0.4.1"
 
 [build-dependencies]
-protobuf-codegen-pure = "2"
+protobuf-codegen = "3"

--- a/build.rs
+++ b/build.rs
@@ -1,12 +1,14 @@
-use protobuf_codegen_pure::{ Codegen, Customize };
+use protobuf_codegen_pure::{Codegen, Customize};
 
 fn main() {
-   // Build our realtime feed structure
-   Codegen::new()
-      .out_dir("src/yahoo")
-      .inputs(&["src/yahoo/realtime.proto"])
-      .includes(&[ "src" ])
-      .customize(Customize { ..Default::default() })
-      .run()
-      .expect("Codegen failed.");
+    // Build our realtime feed structure
+    Codegen::new()
+        .out_dir("src/yahoo")
+        .inputs(&["src/yahoo/realtime.proto"])
+        .includes(&["src"])
+        .customize(Customize {
+            ..Default::default()
+        })
+        .run()
+        .expect("Codegen failed.");
 }

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,4 @@
-use protobuf_codegen::{Codegen, Customize};
+use protobuf_codegen::Codegen;
 
 fn main() {
     // Build our realtime feed structure
@@ -6,9 +6,6 @@ fn main() {
         .out_dir("src/yahoo/gen")
         .inputs(&["src/yahoo/realtime.proto"])
         .includes(&["src"])
-        /*.customize(Customize {
-            ..Default::default()
-        })*/
         .run()
         .expect("Codegen failed.");
 }

--- a/build.rs
+++ b/build.rs
@@ -1,14 +1,14 @@
-use protobuf_codegen_pure::{Codegen, Customize};
+use protobuf_codegen::{Codegen, Customize};
 
 fn main() {
     // Build our realtime feed structure
     Codegen::new()
-        .out_dir("src/yahoo")
+        .out_dir("src/yahoo/gen")
         .inputs(&["src/yahoo/realtime.proto"])
         .includes(&["src"])
-        .customize(Customize {
+        /*.customize(Customize {
             ..Default::default()
-        })
+        })*/
         .run()
         .expect("Codegen failed.");
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,45 +6,48 @@ use snafu::Snafu;
 #[derive(Debug, Snafu)]
 #[snafu(visibility = "pub(crate)")]
 pub enum InnerError {
-   #[snafu(display("Yahoo! returned invalid data - {}", source.to_string()))]
-   BadData { source: serde_json::Error },
+    #[snafu(display("Yahoo! returned invalid data - {}", source.to_string()))]
+    BadData { source: serde_json::Error },
 
-   #[snafu(display("Yahoo! call failed. '{}' returned a {} result.", url, status))]
-   CallFailed { url: String, status: u16 },
+    #[snafu(display("Yahoo! call failed. '{}' returned a {} result.", url, status))]
+    CallFailed { url: String, status: u16 },
 
-   #[snafu(display("Yahoo! chart failed to load {} - {}.", code, description))]
-   ChartFailed { code: String, description: String },
+    #[snafu(display("Yahoo! chart failed to load {} - {}.", code, description))]
+    ChartFailed { code: String, description: String },
 
-   #[snafu(display("An internal error occurred - please report that '{}'", reason))]
-   InternalLogic { reason: String },
+    #[snafu(display("An internal error occurred - please report that '{}'", reason))]
+    InternalLogic { reason: String },
 
-   #[snafu(display("An internal error occurred - please report that '{}' cannot be parsed because {}", url, source.to_string()))]
-   InternalURL { url: String, source: url::ParseError },
+    #[snafu(display("An internal error occurred - please report that '{}' cannot be parsed because {}", url, source.to_string()))]
+    InternalURL {
+        url: String,
+        source: url::ParseError,
+    },
 
-   #[snafu(display("Start date cannot be after the end date"))]
-   InvalidStartDate,
+    #[snafu(display("Start date cannot be after the end date"))]
+    InvalidStartDate,
 
-   #[snafu(display("Yahoo! returned invalid data - {}", reason))]
-   MissingData { reason: String },
+    #[snafu(display("Yahoo! returned invalid data - {}", reason))]
+    MissingData { reason: String },
 
-   #[snafu(display("Intraday intervals like {} are not allowed", interval))]
-   NoIntraday { interval: Interval },
+    #[snafu(display("Intraday intervals like {} are not allowed", interval))]
+    NoIntraday { interval: Interval },
 
-   #[snafu(display("Yahoo! call failed for unknown reason."))]
-   RequestFailed { source: reqwest::Error },
+    #[snafu(display("Yahoo! call failed for unknown reason."))]
+    RequestFailed { source: reqwest::Error },
 
-   #[snafu(display("Unexpected Yahoo! failure. '{}' returned a {}", url, code))]
-   UnexectedFailure { url: String, code: u16 },
+    #[snafu(display("Unexpected Yahoo! failure. '{}' returned a {}", url, code))]
+    UnexectedFailure { url: String, code: u16 },
 
-   #[snafu(display("Unexpected error while reading data from '{}'", url))]
-   UnexpectedErrorRead { url: String, source: reqwest::Error },
+    #[snafu(display("Unexpected error while reading data from '{}'", url))]
+    UnexpectedErrorRead { url: String, source: reqwest::Error },
 
-   #[snafu(display("Yahoo! call failed.  Expected data is missing."))]
-   UnexpectedErrorYahoo,
+    #[snafu(display("Yahoo! call failed.  Expected data is missing."))]
+    UnexpectedErrorYahoo,
 
-   #[snafu(display("Unexpected error from Yahoo! - data missing"))]
-   Unknown,
+    #[snafu(display("Unexpected error from Yahoo! - data missing"))]
+    Unknown,
 
-   #[snafu(display("We currently do not support securities of type '{}'", kind))]
-   UnsupportedSecurity { kind: String }
+    #[snafu(display("We currently do not support securities of type '{}'", kind))]
+    UnsupportedSecurity { kind: String },
 }

--- a/src/history.rs
+++ b/src/history.rs
@@ -3,14 +3,27 @@ use snafu::{ensure, OptionExt};
 
 use crate::{error, yahoo, Bar, Interval, Result};
 
-fn aggregate_bars(data: yahoo::Data) -> Result<Vec<Bar>> {
-   let mut result = Vec::new();
+fn extract_events(data: yahoo::Data) -> (Vec<yahoo::Dividend>, Vec<yahoo::Split>) {
+    let events = match data.events {
+        None => return (Vec::new(), Vec::new()),
+        Some(events) => events,
+    };
+    // The API returns events as a map by date; here we simply flatten to a `Vec`
+    let dividends = events.dividends.map(|ds| ds.into_iter().map(|(_date, mut dividend)| { dividend.timestamp *= 1000; dividend }).collect()).unwrap_or_else(Vec::new);
+    let splits = events.splits.map(|ss| ss.into_iter().map(|(_date, mut split)| { split.timestamp *= 1000; split }).collect()).unwrap_or_else(Vec::new);
+    (dividends, splits)
+}
 
+fn aggregate_bars_and_extract_events(data: yahoo::Data) -> Result<(Vec<Bar>, Vec<yahoo::Dividend>, Vec<yahoo::Split>)> {
+   let mut result = Vec::new();
    let timestamps = &data.timestamps;
    let quotes = &data.indicators.quotes;
 
    // if we have no timestamps & no quotes we'll assume there is no data
-   if timestamps.is_empty() && quotes.is_empty() { return Ok(result); }
+   if timestamps.is_empty() && quotes.is_empty() {
+       let (dividends, splits) = extract_events(data);
+       return Ok((result, dividends, splits));
+   }
 
    // otherwise see if one is empty and reflects bad data from Yahoo!
    ensure!(!timestamps.is_empty(), error::MissingData { reason: "no timestamps for OHLCV data" });
@@ -40,7 +53,9 @@ fn aggregate_bars(data: yahoo::Data) -> Result<Vec<Bar>> {
          volume: quote.volumes[i],
       })
    }
-   Ok(result)
+
+   let (dividends, splits) = extract_events(data);
+   Ok((result, dividends, splits))
 }
 
 /// Retrieves (at most) 6 months worth of OCLHV data for a symbol
@@ -65,7 +80,38 @@ fn aggregate_bars(data: yahoo::Data) -> Result<Vec<Bar>> {
 /// }
 /// ```
 pub async fn retrieve(symbol: &str) -> Result<Vec<Bar>> {
-   aggregate_bars(yahoo::load_daily(symbol, Interval::_6mo).await?)
+   aggregate_bars_and_extract_events(yahoo::load_daily(symbol, Interval::_6mo).await?).map(|(bars, _dividends, _splits)| bars)
+}
+
+/// Retrieves (at most) 6 months worth of OCLHV and corporate action event data for a symbol
+///
+/// # Examples
+///
+/// Get any Apple corporate actions within the last 6 months:
+///
+/// ``` no_run
+/// use yahoo_finance::{ history, Timestamped };
+///
+/// #[tokio::main]
+/// async fn main() {
+///    match history::retrieve_with_events("AAPL").await {
+///       Err(e) => println!("Failed to call Yahoo: {:?}", e),
+///       Ok((bars, dividends, splits)) => {
+///          for bar in &bars {
+///             println!("On {} Apple closed at ${:.2}", bar.datetime().format("%b %e %Y"), bar.close)
+///          }
+///          for dividend in &dividends {
+///             println!("Apple dividend of {} on {}", dividend.amount, dividend.datetime().format("%b %e %Y"))
+///          }
+///          for split in &splits {
+///             println!("Apple split {}:{} on {}", split.numerator, split.denominator, split.datetime().format("%b %e %Y"))
+///          }
+///       }
+///    }
+/// }
+/// ```
+pub async fn retrieve_with_events(symbol: &str) -> Result<(Vec<Bar>, Vec<yahoo::Dividend>, Vec<yahoo::Split>)> {
+    yahoo::load_daily_with_events(symbol, Interval::_6mo).await.and_then(aggregate_bars_and_extract_events)
 }
 
 /// Retrieves a configurable amount of OCLHV data for a symbol
@@ -95,7 +141,42 @@ pub async fn retrieve_interval(symbol: &str, interval: Interval) -> Result<Vec<B
    // pre-conditions
    ensure!(!interval.is_intraday(), error::NoIntraday { interval });
 
-   aggregate_bars(yahoo::load_daily(symbol, interval).await?)
+   aggregate_bars_and_extract_events(yahoo::load_daily(symbol, interval).await?).map(|(bars, _dividends, _splits)| bars)
+}
+
+/// Retrieves a configurable amount of OCLHV and corporate action event data for a symbol.  The amount of
+/// data returned might be less than the interval specified if the symbol is new.
+///
+/// # Examples
+///
+/// Get 5 days worth of Apple data:
+///
+/// ``` no_run
+/// use yahoo_finance::{ history, Interval, Timestamped };
+///
+/// #[tokio::main]
+/// async fn main() {
+///    match history::retrieve_interval_with_events("AAPL", Interval::_5d).await {
+///       Err(e) => println!("Failed to call Yahoo: {:?}", e),
+///       Ok((bars, dividends, splits)) => {
+///          for bar in &bars {
+///             println!("On {} Apple closed at ${:.2}", bar.datetime().format("%b %e %Y"), bar.close)
+///          }
+///          for dividend in &dividends {
+///             println!("Apple dividend of {} on {}", dividend.amount, dividend.datetime().format("%b %e %Y"))
+///          }
+///          for split in &splits {
+///             println!("Apple split {}:{} on {}", split.numerator, split.denominator, split.datetime().format("%b %e %Y"))
+///          }
+///       }
+///    }
+/// }
+/// ```
+pub async fn retrieve_interval_with_events(symbol: &str, interval: Interval) -> Result<(Vec<Bar>, Vec<yahoo::Dividend>, Vec<yahoo::Split>)> {
+   // pre-conditions
+   ensure!(!interval.is_intraday(), error::NoIntraday { interval });
+
+   yahoo::load_daily_with_events(symbol, interval).await.and_then(aggregate_bars_and_extract_events)
 }
 
 /// Retrieves OCLHV data for a symbol between a start and end date.
@@ -125,5 +206,42 @@ pub async fn retrieve_range(symbol: &str, start: DateTime<Utc>, end: Option<Date
    let _end = end.unwrap_or_else(Utc::now);
    ensure!(_end.signed_duration_since(start).num_seconds() > 0, error::InvalidStartDate);
 
-   aggregate_bars(yahoo::load_daily_range(symbol, start.timestamp(), _end.timestamp()).await?)
+   aggregate_bars_and_extract_events(yahoo::load_daily_range(symbol, start.timestamp(), _end.timestamp()).await?).map(|(bars, _dividends, _splits)| bars)
+}
+
+/// Retrieves OCLHV and corporate action event data for a symbol between a start and end date.
+///
+/// # Examples
+///
+/// Get 5 days worth of Apple data:
+///
+/// ``` no_run
+/// use chrono::{Duration, TimeZone, Utc};
+/// use yahoo_finance::{ history, Timestamped };
+///
+/// #[tokio::main]
+/// async fn main() {
+///    let now = Utc::now();
+///    match history::retrieve_range_with_events("AAPL", now - Duration::days(30), Some(now - Duration::days(10))).await {
+///       Err(e) => println!("Failed to call Yahoo {:?}", e),
+///       Ok((bars, dividends, splits)) => {
+///          for bar in &bars {
+///             println!("On {} Apple closed at ${:.2}", bar.datetime().format("%b %e %Y"), bar.close)
+///          }
+///          for dividend in &dividends {
+///             println!("Apple dividend of {} on {}", dividend.amount, dividend.datetime().format("%b %e %Y"))
+///          }
+///          for split in &splits {
+///             println!("Apple split {}:{} on {}", split.numerator, split.denominator, split.datetime().format("%b %e %Y"))
+///          }
+///       }
+///    }
+/// }
+/// ```
+pub async fn retrieve_range_with_events(symbol: &str, start: DateTime<Utc>, end: Option<DateTime<Utc>>) -> Result<(Vec<Bar>, Vec<yahoo::Dividend>, Vec<yahoo::Split>)> {
+   // pre-conditions
+   let _end = end.unwrap_or_else(Utc::now);
+   ensure!(_end.signed_duration_since(start).num_seconds() > 0, error::InvalidStartDate);
+
+   yahoo::load_daily_range_with_events(symbol, start.timestamp(), _end.timestamp()).await.and_then(aggregate_bars_and_extract_events)
 }

--- a/src/history.rs
+++ b/src/history.rs
@@ -9,53 +9,122 @@ fn extract_events(data: yahoo::Data) -> (Vec<yahoo::Dividend>, Vec<yahoo::Split>
         Some(events) => events,
     };
     // The API returns events as a map by date; here we simply flatten to a `Vec`
-    let dividends = events.dividends.map(|ds| ds.into_iter().map(|(_date, mut dividend)| { dividend.timestamp *= 1000; dividend }).collect()).unwrap_or_else(Vec::new);
-    let splits = events.splits.map(|ss| ss.into_iter().map(|(_date, mut split)| { split.timestamp *= 1000; split }).collect()).unwrap_or_else(Vec::new);
+    let dividends = events
+        .dividends
+        .map(|ds| {
+            ds.into_iter()
+                .map(|(_date, mut dividend)| {
+                    dividend.timestamp *= 1000;
+                    dividend
+                })
+                .collect()
+        })
+        .unwrap_or_else(Vec::new);
+    let splits = events
+        .splits
+        .map(|ss| {
+            ss.into_iter()
+                .map(|(_date, mut split)| {
+                    split.timestamp *= 1000;
+                    split
+                })
+                .collect()
+        })
+        .unwrap_or_else(Vec::new);
     (dividends, splits)
 }
 
-fn aggregate_bars_and_extract_events(data: yahoo::Data) -> Result<(Vec<Bar>, Vec<yahoo::Dividend>, Vec<yahoo::Split>)> {
-   let mut result = Vec::new();
-   let timestamps = &data.timestamps;
-   let quotes = &data.indicators.quotes;
+fn aggregate_bars_and_extract_events(
+    data: yahoo::Data,
+) -> Result<(Vec<Bar>, Vec<yahoo::Dividend>, Vec<yahoo::Split>)> {
+    let mut result = Vec::new();
+    let timestamps = &data.timestamps;
+    let quotes = &data.indicators.quotes;
 
-   // if we have no timestamps & no quotes we'll assume there is no data
-   if timestamps.is_empty() && quotes.is_empty() {
-       let (dividends, splits) = extract_events(data);
-       return Ok((result, dividends, splits));
-   }
+    // if we have no timestamps & no quotes we'll assume there is no data
+    if timestamps.is_empty() && quotes.is_empty() {
+        let (dividends, splits) = extract_events(data);
+        return Ok((result, dividends, splits));
+    }
 
-   // otherwise see if one is empty and reflects bad data from Yahoo!
-   ensure!(!timestamps.is_empty(), error::MissingData { reason: "no timestamps for OHLCV data" });
-   ensure!(!quotes.is_empty(), error::MissingData { reason: "no OHLCV data" });
+    // otherwise see if one is empty and reflects bad data from Yahoo!
+    ensure!(
+        !timestamps.is_empty(),
+        error::MissingData {
+            reason: "no timestamps for OHLCV data"
+        }
+    );
+    ensure!(
+        !quotes.is_empty(),
+        error::MissingData {
+            reason: "no OHLCV data"
+        }
+    );
 
-   // make sure timestamps lines up with the OHLCV data
-   let quote = &quotes[0];
-   ensure!(timestamps.len() == quote.volumes.len(), error::MissingData { reason: "timestamps do not line up with OHLCV data" });
-   ensure!(timestamps.len() == quote.opens.len(), error::MissingData { reason: "'open' values do not line up the timestamps" });
-   ensure!(timestamps.len() == quote.highs.len(), error::MissingData { reason: "'high' values do not line up the timestamps" });
-   ensure!(timestamps.len() == quote.lows.len(), error::MissingData { reason: "'low' values do not line up the timestamps" });
-   ensure!(timestamps.len() == quote.closes.len(), error::MissingData { reason: "'close' values do not line up the timestamps" });
+    // make sure timestamps lines up with the OHLCV data
+    let quote = &quotes[0];
+    ensure!(
+        timestamps.len() == quote.volumes.len(),
+        error::MissingData {
+            reason: "timestamps do not line up with OHLCV data"
+        }
+    );
+    ensure!(
+        timestamps.len() == quote.opens.len(),
+        error::MissingData {
+            reason: "'open' values do not line up the timestamps"
+        }
+    );
+    ensure!(
+        timestamps.len() == quote.highs.len(),
+        error::MissingData {
+            reason: "'high' values do not line up the timestamps"
+        }
+    );
+    ensure!(
+        timestamps.len() == quote.lows.len(),
+        error::MissingData {
+            reason: "'low' values do not line up the timestamps"
+        }
+    );
+    ensure!(
+        timestamps.len() == quote.closes.len(),
+        error::MissingData {
+            reason: "'close' values do not line up the timestamps"
+        }
+    );
 
-   #[allow(clippy::needless_range_loop)]
-   for i in 0..timestamps.len() {
-      // skip days where we have incomplete data
-      if quote.opens[i].is_none() || quote.highs[i].is_none() || quote.lows[i].is_none() || quote.closes[i].is_none() {
-         continue;
-      }
+    #[allow(clippy::needless_range_loop)]
+    for i in 0..timestamps.len() {
+        // skip days where we have incomplete data
+        if quote.opens[i].is_none()
+            || quote.highs[i].is_none()
+            || quote.lows[i].is_none()
+            || quote.closes[i].is_none()
+        {
+            continue;
+        }
 
-      result.push(Bar {
-         timestamp: timestamps[i] * 1000,
-         open: quote.opens[i].context(error::InternalLogic{ reason: "missing open not caught" })?,
-         high: quote.highs[i].context(error::InternalLogic{ reason: "missing high not caught" })?,
-         low: quote.lows[i].context(error::InternalLogic{ reason: "missing low not caught" })?,
-         close: quote.closes[i].context(error::InternalLogic{ reason: "missing close not caught" })?,
-         volume: quote.volumes[i],
-      })
-   }
+        result.push(Bar {
+            timestamp: timestamps[i] * 1000,
+            open: quote.opens[i].context(error::InternalLogic {
+                reason: "missing open not caught",
+            })?,
+            high: quote.highs[i].context(error::InternalLogic {
+                reason: "missing high not caught",
+            })?,
+            low: quote.lows[i].context(error::InternalLogic {
+                reason: "missing low not caught",
+            })?,
+            close: quote.closes[i].context(error::InternalLogic {
+                reason: "missing close not caught",
+            })?,
+            volume: quote.volumes[i],
+        })
+    }
 
-   let (dividends, splits) = extract_events(data);
-   Ok((result, dividends, splits))
+    let (dividends, splits) = extract_events(data);
+    Ok((result, dividends, splits))
 }
 
 /// Retrieves (at most) 6 months worth of OCLHV data for a symbol
@@ -72,15 +141,16 @@ fn aggregate_bars_and_extract_events(data: yahoo::Data) -> Result<(Vec<Bar>, Vec
 /// async fn main() {
 ///    match history::retrieve("AAPL").await {
 ///       Err(e) => println!("Failed to call Yahoo: {:?}", e),
-///       Ok(data) => 
+///       Ok(data) =>
 ///          for bar in &data {
 ///             println!("On {} Apple closed at ${:.2}", bar.datetime().format("%b %e %Y"), bar.close)
 ///          }
 ///    }
 /// }
 /// ```
-pub async fn retrieve(symbol: &str) -> Result<Vec<Bar>> {
-   aggregate_bars_and_extract_events(yahoo::load_daily(symbol, Interval::_6mo).await?).map(|(bars, _dividends, _splits)| bars)
+pub async fn retrieve(user_agent: &str, symbol: &str) -> Result<Vec<Bar>> {
+    aggregate_bars_and_extract_events(yahoo::load_daily(user_agent, symbol, Interval::_6mo).await?)
+        .map(|(bars, _dividends, _splits)| bars)
 }
 
 /// Retrieves (at most) 6 months worth of OCLHV and corporate action event data for a symbol
@@ -110,8 +180,13 @@ pub async fn retrieve(symbol: &str) -> Result<Vec<Bar>> {
 ///    }
 /// }
 /// ```
-pub async fn retrieve_with_events(symbol: &str) -> Result<(Vec<Bar>, Vec<yahoo::Dividend>, Vec<yahoo::Split>)> {
-    yahoo::load_daily_with_events(symbol, Interval::_6mo).await.and_then(aggregate_bars_and_extract_events)
+pub async fn retrieve_with_events(
+    user_agent: &str,
+    symbol: &str,
+) -> Result<(Vec<Bar>, Vec<yahoo::Dividend>, Vec<yahoo::Split>)> {
+    yahoo::load_daily_with_events(user_agent, symbol, Interval::_6mo)
+        .await
+        .and_then(aggregate_bars_and_extract_events)
 }
 
 /// Retrieves a configurable amount of OCLHV data for a symbol
@@ -130,18 +205,23 @@ pub async fn retrieve_with_events(symbol: &str) -> Result<(Vec<Bar>, Vec<yahoo::
 /// async fn main() {
 ///    match history::retrieve_interval("AAPL", Interval::_5d).await {
 ///       Err(e) => println!("Failed to call Yahoo: {:?}", e),
-///       Ok(data) => 
+///       Ok(data) =>
 ///          for bar in &data {
 ///             println!("On {} Apple closed at ${:.2}", bar.datetime().format("%b %e %Y"), bar.close)
 ///          }
 ///    }
 /// }
 /// ```
-pub async fn retrieve_interval(symbol: &str, interval: Interval) -> Result<Vec<Bar>> {
-   // pre-conditions
-   ensure!(!interval.is_intraday(), error::NoIntraday { interval });
+pub async fn retrieve_interval(
+    user_agent: &str,
+    symbol: &str,
+    interval: Interval,
+) -> Result<Vec<Bar>> {
+    // pre-conditions
+    ensure!(!interval.is_intraday(), error::NoIntraday { interval });
 
-   aggregate_bars_and_extract_events(yahoo::load_daily(symbol, interval).await?).map(|(bars, _dividends, _splits)| bars)
+    aggregate_bars_and_extract_events(yahoo::load_daily(user_agent, symbol, interval).await?)
+        .map(|(bars, _dividends, _splits)| bars)
 }
 
 /// Retrieves a configurable amount of OCLHV and corporate action event data for a symbol.  The amount of
@@ -172,11 +252,17 @@ pub async fn retrieve_interval(symbol: &str, interval: Interval) -> Result<Vec<B
 ///    }
 /// }
 /// ```
-pub async fn retrieve_interval_with_events(symbol: &str, interval: Interval) -> Result<(Vec<Bar>, Vec<yahoo::Dividend>, Vec<yahoo::Split>)> {
-   // pre-conditions
-   ensure!(!interval.is_intraday(), error::NoIntraday { interval });
+pub async fn retrieve_interval_with_events(
+    user_agent: &str,
+    symbol: &str,
+    interval: Interval,
+) -> Result<(Vec<Bar>, Vec<yahoo::Dividend>, Vec<yahoo::Split>)> {
+    // pre-conditions
+    ensure!(!interval.is_intraday(), error::NoIntraday { interval });
 
-   yahoo::load_daily_with_events(symbol, interval).await.and_then(aggregate_bars_and_extract_events)
+    yahoo::load_daily_with_events(user_agent, symbol, interval)
+        .await
+        .and_then(aggregate_bars_and_extract_events)
 }
 
 /// Retrieves OCLHV data for a symbol between a start and end date.
@@ -201,12 +287,23 @@ pub async fn retrieve_interval_with_events(symbol: &str, interval: Interval) -> 
 ///    }
 /// }
 /// ```
-pub async fn retrieve_range(symbol: &str, start: DateTime<Utc>, end: Option<DateTime<Utc>>) -> Result<Vec<Bar>> {
-   // pre-conditions
-   let _end = end.unwrap_or_else(Utc::now);
-   ensure!(_end.signed_duration_since(start).num_seconds() > 0, error::InvalidStartDate);
+pub async fn retrieve_range(
+    user_agent: &str,
+    symbol: &str,
+    start: DateTime<Utc>,
+    end: Option<DateTime<Utc>>,
+) -> Result<Vec<Bar>> {
+    // pre-conditions
+    let _end = end.unwrap_or_else(Utc::now);
+    ensure!(
+        _end.signed_duration_since(start).num_seconds() > 0,
+        error::InvalidStartDate
+    );
 
-   aggregate_bars_and_extract_events(yahoo::load_daily_range(symbol, start.timestamp(), _end.timestamp()).await?).map(|(bars, _dividends, _splits)| bars)
+    aggregate_bars_and_extract_events(
+        yahoo::load_daily_range(user_agent, symbol, start.timestamp(), _end.timestamp()).await?,
+    )
+    .map(|(bars, _dividends, _splits)| bars)
 }
 
 /// Retrieves OCLHV and corporate action event data for a symbol between a start and end date.
@@ -238,10 +335,20 @@ pub async fn retrieve_range(symbol: &str, start: DateTime<Utc>, end: Option<Date
 ///    }
 /// }
 /// ```
-pub async fn retrieve_range_with_events(symbol: &str, start: DateTime<Utc>, end: Option<DateTime<Utc>>) -> Result<(Vec<Bar>, Vec<yahoo::Dividend>, Vec<yahoo::Split>)> {
-   // pre-conditions
-   let _end = end.unwrap_or_else(Utc::now);
-   ensure!(_end.signed_duration_since(start).num_seconds() > 0, error::InvalidStartDate);
+pub async fn retrieve_range_with_events(
+    user_agent: &str,
+    symbol: &str,
+    start: DateTime<Utc>,
+    end: Option<DateTime<Utc>>,
+) -> Result<(Vec<Bar>, Vec<yahoo::Dividend>, Vec<yahoo::Split>)> {
+    // pre-conditions
+    let _end = end.unwrap_or_else(Utc::now);
+    ensure!(
+        _end.signed_duration_since(start).num_seconds() > 0,
+        error::InvalidStartDate
+    );
 
-   yahoo::load_daily_range_with_events(symbol, start.timestamp(), _end.timestamp()).await.and_then(aggregate_bars_and_extract_events)
+    yahoo::load_daily_range_with_events(user_agent, symbol, start.timestamp(), _end.timestamp())
+        .await
+        .and_then(aggregate_bars_and_extract_events)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 //! * Historical quote information [OHCL Data](https://en.wikipedia.org/wiki/Open-high-low-close_chart) + volume
 //! * Relatively real-time quote informaton with comparible performance to the real-time updates on their website
 //! * Company profile information including address, sector, industry, etc.
-//! 
+//!
 //! ## Quick Examples
 //!
 //! To retrieve the intraday high for the last 3 months of Apple you can use something like:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(soft_unstable)]
 //! # Yahoo Finance
 //!
 //! Yahoo! provides some great market data and this is a library to easily get

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,6 +1,7 @@
 /// Used in conjunction with Serde to create good public structures
 macro_rules! ez_serde {
    ($name:ident$(< $( $lt:lifetime ),+ >)? { $($(#[$m:meta])? $field:ident: $t:ty),* } ) => {
+      #[allow(dead_code)]
       #[derive(Clone, Deserialize)]
       #[serde(rename_all(deserialize = "camelCase"))]
       pub struct $name$(< $($lt),* >)? {

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -4,98 +4,99 @@ use crate::{error, yahoo, Result};
 /// This is usually the company headquarters.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Address {
-   pub street1: Option<String>,
-   pub street2: Option<String>,
-   pub city: Option<String>,
-   pub state: Option<String>,
-   pub country: Option<String>,
-   pub zip: Option<String>,
+    pub street1: Option<String>,
+    pub street2: Option<String>,
+    pub city: Option<String>,
+    pub state: Option<String>,
+    pub country: Option<String>,
+    pub zip: Option<String>,
 }
 impl Address {
-   fn new(data: &yahoo::CompanyProfile) -> Result<Address> {
-
-      Ok(Address {
-         street1: data.address1.clone(),
-         street2: data.address2.clone(),
-         city: data.city.clone(),
-         state: data.state.clone(),
-         country: data.country.clone(),
-         zip: data.zip.clone()
-      })
-   }
+    fn new(data: &yahoo::CompanyProfile) -> Result<Address> {
+        Ok(Address {
+            street1: data.address1.clone(),
+            street2: data.address2.clone(),
+            city: data.city.clone(),
+            state: data.state.clone(),
+            country: data.country.clone(),
+            zip: data.zip.clone(),
+        })
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Company {
-   /// Optional address on file for the symbol - typically the HQ for publicly
-   /// traded companies.
-   pub address: Option<Address>,
+    /// Optional address on file for the symbol - typically the HQ for publicly
+    /// traded companies.
+    pub address: Option<Address>,
 
-   /// The industry, according to Yahoo.  ie. 'Gold'
-   pub industry: Option<String>,
+    /// The industry, according to Yahoo.  ie. 'Gold'
+    pub industry: Option<String>,
 
-   /// The common name for the symbol.
-   pub name: String,
+    /// The common name for the symbol.
+    pub name: String,
 
-   // The sector, according to Yahoo.  ie. 'Basic Materials'
-   pub sector: Option<String>,
+    // The sector, according to Yahoo.  ie. 'Basic Materials'
+    pub sector: Option<String>,
 
-   /// A summary description for the symbol.
-   pub summary: Option<String>,
+    /// A summary description for the symbol.
+    pub summary: Option<String>,
 
-   /// A website with more information - generally a corporate home page.
-   pub website: Option<String>
+    /// A website with more information - generally a corporate home page.
+    pub website: Option<String>,
 }
 impl Company {
-   fn new(data: yahoo::QuoteSummaryStore) -> Result<Company> {
-      let profile = data.company_profile.expect("asdf");
-      let address = Some(Address::new(&profile)?);
+    fn new(data: yahoo::QuoteSummaryStore) -> Result<Company> {
+        let profile = data.company_profile.expect("asdf");
+        let address = Some(Address::new(&profile)?);
 
-      Ok(Company {
-         name: data.quote_type.name,
-         summary: profile.summary,
-         address,
-         industry: profile.industry,
-         sector: profile.sector,
-         website: profile.website,
-      })
-   }
+        Ok(Company {
+            name: data.quote_type.name,
+            summary: profile.summary,
+            address,
+            industry: profile.industry,
+            sector: profile.sector,
+            website: profile.website,
+        })
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Fund {
-   pub name: String,
+    pub name: String,
 
-   pub family: Option<String>,
+    pub family: Option<String>,
 
-   pub kind: String
+    pub kind: String,
 }
 impl Fund {
-   fn new(data: yahoo::QuoteSummaryStore) -> Result<Fund> {
-      let profile = data.fund_profile.expect("asdf");
+    fn new(data: yahoo::QuoteSummaryStore) -> Result<Fund> {
+        let profile = data.fund_profile.expect("asdf");
 
-      Ok(Fund {
-         name: data.quote_type.name,
-         kind: profile.kind,
-         family: profile.family
-      })
-   }
+        Ok(Fund {
+            name: data.quote_type.name,
+            kind: profile.kind,
+            family: profile.family,
+        })
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum Profile {
-   Company(Company),
-   Fund(Fund)
+    Company(Company),
+    Fund(Fund),
 }
 impl Profile {
-   pub async fn load(symbol: &str) -> Result<Profile> {
-      let data = yahoo::scrape(symbol).await?.quote_summary_store;
+    pub async fn load(symbol: &str) -> Result<Profile> {
+        let data = yahoo::scrape(symbol).await?.quote_summary_store;
 
-      let kind = &data.quote_type.kind;
-      match kind.as_str() {
-         "EQUITY" => Ok(Self::Company(Company::new(data)?)),
-         "ETF" => Ok(Self::Fund(Fund::new(data)?)),
-         _ => (error::UnsupportedSecurity { kind }).fail().map_err(core::convert::Into::into)
-      }
-   }
+        let kind = &data.quote_type.kind;
+        match kind.as_str() {
+            "EQUITY" => Ok(Self::Company(Company::new(data)?)),
+            "ETF" => Ok(Self::Fund(Fund::new(data)?)),
+            _ => (error::UnsupportedSecurity { kind })
+                .fail()
+                .map_err(core::convert::Into::into),
+        }
+    }
 }

--- a/src/streaming.rs
+++ b/src/streaming.rs
@@ -1,27 +1,26 @@
 use base64::decode;
-use futures::{ future, Stream, SinkExt, StreamExt };
-use protobuf::parse_from_bytes;
+use futures::{future, SinkExt, Stream, StreamExt};
 use serde::Serialize;
-use std::sync::{ mpsc, Arc, Mutex };
-use tokio_tungstenite::{ connect_async, tungstenite::protocol::Message };
+use tokio::sync::mpsc;
+use tokio_tungstenite::{connect_async, tungstenite::protocol::Message};
 
-use crate::{ TradingSession };
-use crate::yahoo::{ PricingData, PricingData_MarketHoursType };
+use crate::yahoo::{PricingData, PricingData_MarketHoursType};
+use crate::TradingSession;
 
-use super::{ Quote };
+use super::Quote;
 
 #[derive(Debug, Clone, Serialize)]
 struct Subs {
-   subscribe: Vec<String>,
+    subscribe: Vec<String>,
 }
 
 fn convert_session(value: PricingData_MarketHoursType) -> TradingSession {
-   match value {
-      PricingData_MarketHoursType::PRE_MARKET => TradingSession::PreMarket,
-      PricingData_MarketHoursType::REGULAR_MARKET => TradingSession::Regular,
-      PricingData_MarketHoursType::POST_MARKET => TradingSession::AfterHours,
-      _ => TradingSession::Other,
-   }
+    match value {
+        PricingData_MarketHoursType::PRE_MARKET => TradingSession::PreMarket,
+        PricingData_MarketHoursType::REGULAR_MARKET => TradingSession::Regular,
+        PricingData_MarketHoursType::POST_MARKET => TradingSession::AfterHours,
+        _ => TradingSession::Other,
+    }
 }
 
 /// Realtime price quote streamer
@@ -31,69 +30,86 @@ fn convert_session(value: PricingData_MarketHoursType) -> TradingSession {
 /// 1. Subscribe to some symbols with `streamer.subscribe(vec!["AAPL"], |quote| /* do something */).await;`
 /// 1. Let the streamer run `streamer.run().await;`
 pub struct Streamer {
-   subs: Vec<String>,
-   shutdown: Arc<Mutex<bool>>
+    subs: Vec<String>,
+    shutdown: Option<mpsc::UnboundedSender<Option<Message>>>,
 }
+
 impl Streamer {
-   pub fn new(symbols: Vec<&str>) -> Streamer {
-      let mut subs = Vec::new();
-      for symbol in &symbols { subs.push(symbol.to_string()); }
+    pub fn new(symbols: Vec<&str>) -> Streamer {
+        let mut subs = Vec::new();
+        for symbol in &symbols {
+            subs.push(symbol.to_string());
+        }
 
-      Streamer { subs, shutdown: Arc::new(Mutex::new(false)) }
-   }
+        Streamer {
+            subs,
+            shutdown: None,
+        }
+    }
 
-   pub async fn stream(&self) -> impl Stream<Item = Quote> {
-      let (tx, rx) = mpsc::channel();
+    pub async fn stream(&mut self) -> impl Stream<Item = Quote> {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        self.shutdown = Some(tx.clone());
 
-      let (stream, _) = connect_async("wss://streamer.finance.yahoo.com").await.unwrap();
-      let (mut sink, source) = stream.split();
+        let (stream, _) = connect_async("wss://streamer.finance.yahoo.com")
+            .await
+            .unwrap();
+        let (mut sink, source) = stream.split();
 
-      // send the symbols we are interested in streaming
-      let message = serde_json::to_string(&Subs { subscribe: self.subs.clone() }).unwrap();
-      tx.send(Message::Text(message)).unwrap();
+        // send the symbols we are interested in streaming
+        let message = serde_json::to_string(&Subs {
+            subscribe: self.subs.clone(),
+        })
+        .unwrap();
+        tx.send(Some(Message::Text(message))).unwrap();
 
-      // spawn a separate thread for sending out messages
-      let shutdown = self.shutdown.clone();
-      tokio::spawn(async move {
-         loop {
-            // stop on shutdown notification
-            if *(shutdown.lock().unwrap()) { break; }
-
-            // we're still running - so get a message and send it out.
-            // TODO - change this to WAIT on receive so that we don't block shutdown
-            let msg = rx.recv().unwrap();
-            sink.send(msg).await.unwrap();
-         }
-      });
-
-      let pong_tx = tx.clone();
-      let shutdown = self.shutdown.clone();
-      source
-         .filter_map(move |msg| {
-            match msg.unwrap() {
-               Message::Ping(_) => { pong_tx.send(Message::Pong("pong".as_bytes().to_vec())).unwrap(); },
-               Message::Close(_) => { *(shutdown.lock().unwrap()) = true; },
-               Message::Text(value) => { return future::ready(Some(value)); },
-               Message::Binary(value) => { return future::ready(Some(String::from_utf8(value).unwrap())); },
-               _ => {}
-            };
-            return future::ready(None)
-         })
-         .map(move |msg| {
-            let data = parse_from_bytes::<PricingData>(&decode(msg).unwrap()).unwrap();
-
-            Quote {
-               symbol: data.id.to_string(),
-               timestamp: data.time as i64,
-               session: convert_session(data.marketHours),
-               price: data.price as f64,
-               volume: data.dayVolume as u64
+        // background task to dispatch messages to the WS sink
+        // we cannot dispatch to it directly in `filter_map` as
+        // trying to pass an async closure captures its environment
+        // TODO: What is being captured in that case?
+        tokio::spawn(async move {
+            while let Some(msg) = rx.recv().await.unwrap() {
+                sink.send(msg).await.unwrap();
             }
-         })
-   }
+        });
 
-   pub fn stop(&mut self) {
-      let mut shutdown = self.shutdown.lock().unwrap();
-      *shutdown = true;
-   }
+        source
+            .filter_map(move |msg| {
+                match msg.unwrap() {
+                    Message::Ping(_) => {
+                        tx.send(Some(Message::Pong("pong".as_bytes().to_vec())))
+                            .unwrap();
+                    }
+                    Message::Close(_) => {
+                        tx.send(None).unwrap();
+                    }
+                    Message::Text(value) => {
+                        return future::ready(Some(value));
+                    }
+                    Message::Binary(value) => {
+                        return future::ready(Some(String::from_utf8(value).unwrap()));
+                    }
+                    _ => {}
+                };
+                return future::ready(None);
+            })
+            .map(move |msg| {
+                let data: PricingData =
+                    protobuf::Message::parse_from_bytes(&decode(msg).unwrap()).unwrap();
+
+                Quote {
+                    symbol: data.id.to_string(),
+                    timestamp: data.time as i64,
+                    session: convert_session(data.marketHours),
+                    price: data.price as f64,
+                    volume: data.dayVolume as u64,
+                }
+            })
+    }
+
+    pub async fn stop(&self) {
+        if let Some(shutdown) = &self.shutdown {
+            shutdown.send(None).unwrap();
+        }
+    }
 }

--- a/src/streaming.rs
+++ b/src/streaming.rs
@@ -4,7 +4,7 @@ use serde::Serialize;
 use tokio::sync::mpsc;
 use tokio_tungstenite::{connect_async, tungstenite::protocol::Message};
 
-use crate::yahoo::{PricingData, PricingData_MarketHoursType};
+use crate::yahoo::{MarketHoursType, PricingData};
 use crate::TradingSession;
 
 use super::Quote;
@@ -14,11 +14,11 @@ struct Subs {
     subscribe: Vec<String>,
 }
 
-fn convert_session(value: PricingData_MarketHoursType) -> TradingSession {
+fn convert_session(value: MarketHoursType) -> TradingSession {
     match value {
-        PricingData_MarketHoursType::PRE_MARKET => TradingSession::PreMarket,
-        PricingData_MarketHoursType::REGULAR_MARKET => TradingSession::Regular,
-        PricingData_MarketHoursType::POST_MARKET => TradingSession::AfterHours,
+        MarketHoursType::PRE_MARKET => TradingSession::PreMarket,
+        MarketHoursType::REGULAR_MARKET => TradingSession::Regular,
+        MarketHoursType::POST_MARKET => TradingSession::AfterHours,
         _ => TradingSession::Other,
     }
 }
@@ -100,7 +100,7 @@ impl Streamer {
                 Quote {
                     symbol: data.id.to_string(),
                     timestamp: data.time as i64,
-                    session: convert_session(data.marketHours),
+                    session: convert_session(data.marketHours.enum_value_or_default()),
                     price: data.price as f64,
                     volume: data.dayVolume as u64,
                 }

--- a/src/yahoo/chart.rs
+++ b/src/yahoo/chart.rs
@@ -61,8 +61,8 @@ impl Timestamped for Dividend {
 }
 
 ez_serde!(Split {
-    denominator: u8,
-    numerator: u8,
+    denominator: f64,
+    numerator: f64,
     #[serde(rename = "splitRatio")]
     split_ratio: String,
     #[serde(rename = "date")]

--- a/src/yahoo/chart.rs
+++ b/src/yahoo/chart.rs
@@ -98,7 +98,10 @@ ez_serde!(Response { chart: Chart });
 async fn load(url: &Url) -> Result<Data> {
    // make the call - we do not really expect this to fail.
    // ie - we won't 404 if the symbol doesn't exist
-   let response = reqwest::get(url.clone()).await.context(error::RequestFailed)?;
+   let client = reqwest::ClientBuilder::new()
+        .user_agent("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36")
+        .build().expect("reqwest client");
+   let response = client.get(url.clone()).send().await.context(error::RequestFailed)?;
    ensure!(
       response.status().is_success(),
       error::CallFailed{ url: response.url().to_string(), status: response.status().as_u16() }

--- a/src/yahoo/chart.rs
+++ b/src/yahoo/chart.rs
@@ -2,7 +2,7 @@ use chrono::serde::ts_seconds;
 use chrono::{DateTime, Utc};
 use reqwest::Url;
 use serde::Deserialize;
-use snafu::{ ensure, OptionExt, ResultExt };
+use snafu::{ensure, OptionExt, ResultExt};
 use std::env;
 
 use crate::{error, Interval, Result, Timestamped};
@@ -11,9 +11,11 @@ const BASE_URL: &'static str = "https://query1.finance.yahoo.com/v8/finance/char
 
 /// Helper function to build up the main query URL
 fn build_query(symbol: &str) -> Result<Url> {
-   let base = env::var("TEST_URL").unwrap_or(BASE_URL.to_string());
-   Ok(Url::parse(&base).context(error::InternalURL { url: &base })?
-      .join(symbol).context(error::InternalURL { url: symbol })?)
+    let base = env::var("TEST_URL").unwrap_or(BASE_URL.to_string());
+    Ok(Url::parse(&base)
+        .context(error::InternalURL { url: &base })?
+        .join(symbol)
+        .context(error::InternalURL { url: symbol })?)
 }
 
 ez_serde!(Meta {
@@ -91,38 +93,64 @@ ez_serde!(Data {
    indicators: Indicators
 });
 
-ez_serde!(Error {code: String, description: String });
+ez_serde!(Error {
+    code: String,
+    description: String
+});
 ez_serde!(Chart { result: Option<Vec<Data>>, error: Option<Error> });
 ez_serde!(Response { chart: Chart });
 
-async fn load(url: &Url) -> Result<Data> {
-   // make the call - we do not really expect this to fail.
-   // ie - we won't 404 if the symbol doesn't exist
-   let client = reqwest::ClientBuilder::new()
-        .user_agent("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36")
-        .build().expect("reqwest client");
-   let response = client.get(url.clone()).send().await.context(error::RequestFailed)?;
-   ensure!(
-      response.status().is_success(),
-      error::CallFailed{ url: response.url().to_string(), status: response.status().as_u16() }
-   );
+async fn load(user_agent: &str, url: &Url) -> Result<Data> {
+    // make the call - we do not really expect this to fail.
+    // ie - we won't 404 if the symbol doesn't exist
+    let client = reqwest::ClientBuilder::new()
+        .user_agent(user_agent)
+        .build()
+        .expect("reqwest client");
+    let response = client
+        .get(url.clone())
+        .send()
+        .await
+        .context(error::RequestFailed)?;
+    ensure!(
+        response.status().is_success(),
+        error::CallFailed {
+            url: response.url().to_string(),
+            status: response.status().as_u16()
+        }
+    );
 
-   let data = response.text().await.context(error::UnexpectedErrorRead { url: url.to_string() })?;
-   let chart = serde_json::from_str::<Response>(&data).context(error::BadData)?.chart;
+    let data = response.text().await.context(error::UnexpectedErrorRead {
+        url: url.to_string(),
+    })?;
+    let chart = serde_json::from_str::<Response>(&data)
+        .context(error::BadData)?
+        .chart;
 
-   if !chart.result.is_some() {
-      // no result so we'd better have an error
-      let err = chart.error.context(error::InternalLogic{ reason: "error block exists without values"})?;
-      error::ChartFailed{ code: err.code, description: err.description }.fail()?;
-   }
+    if !chart.result.is_some() {
+        // no result so we'd better have an error
+        let err = chart.error.context(error::InternalLogic {
+            reason: "error block exists without values",
+        })?;
+        error::ChartFailed {
+            code: err.code,
+            description: err.description,
+        }
+        .fail()?;
+    }
 
-   // we have a result to process
-   let result = chart.result.context(error::UnexpectedErrorYahoo)?;
-   ensure!(result.len() > 0, error::UnexpectedErrorYahoo);
-   Ok(result[0].clone())
+    // we have a result to process
+    let result = chart.result.context(error::UnexpectedErrorYahoo)?;
+    ensure!(result.len() > 0, error::UnexpectedErrorYahoo);
+    Ok(result[0].clone())
 }
 
-async fn _load_daily(symbol: &str, period: Interval, with_events: bool) -> Result<Data> {
+async fn _load_daily(
+    user_agent: &str,
+    symbol: &str,
+    period: Interval,
+    with_events: bool,
+) -> Result<Data> {
     let mut lookup = build_query(symbol)?;
     lookup
         .query_pairs_mut()
@@ -132,18 +160,28 @@ async fn _load_daily(symbol: &str, period: Interval, with_events: bool) -> Resul
         lookup.query_pairs_mut().append_pair("events", "div|split");
     }
 
-    load(&lookup).await
+    load(user_agent, &lookup).await
 }
 
-pub async fn load_daily(symbol: &str, period: Interval) -> Result<Data> {
-    _load_daily(symbol, period, false).await
+pub async fn load_daily(user_agent: &str, symbol: &str, period: Interval) -> Result<Data> {
+    _load_daily(user_agent, symbol, period, false).await
 }
 
-pub async fn load_daily_with_events(symbol: &str, period: Interval) -> Result<Data> {
-    _load_daily(symbol, period, true).await
+pub async fn load_daily_with_events(
+    user_agent: &str,
+    symbol: &str,
+    period: Interval,
+) -> Result<Data> {
+    _load_daily(user_agent, symbol, period, true).await
 }
 
-async fn _load_daily_range(symbol: &str, start: i64, end: i64, with_events: bool) -> Result<Data> {
+async fn _load_daily_range(
+    user_agent: &str,
+    symbol: &str,
+    start: i64,
+    end: i64,
+    with_events: bool,
+) -> Result<Data> {
     let mut lookup = build_query(symbol)?;
     lookup
         .query_pairs_mut()
@@ -154,13 +192,23 @@ async fn _load_daily_range(symbol: &str, start: i64, end: i64, with_events: bool
         lookup.query_pairs_mut().append_pair("events", "div|split");
     }
 
-    load(&lookup).await
+    load(user_agent, &lookup).await
 }
 
-pub async fn load_daily_range(symbol: &str, start: i64, end: i64) -> Result<Data> {
-    _load_daily_range(symbol, start, end, false).await
+pub async fn load_daily_range(
+    user_agent: &str,
+    symbol: &str,
+    start: i64,
+    end: i64,
+) -> Result<Data> {
+    _load_daily_range(user_agent, symbol, start, end, false).await
 }
 
-pub async fn load_daily_range_with_events(symbol: &str, start: i64, end: i64) -> Result<Data> {
-    _load_daily_range(symbol, start, end, true).await
+pub async fn load_daily_range_with_events(
+    user_agent: &str,
+    symbol: &str,
+    start: i64,
+    end: i64,
+) -> Result<Data> {
+    _load_daily_range(user_agent, symbol, start, end, true).await
 }

--- a/src/yahoo/gen/mod.rs
+++ b/src/yahoo/gen/mod.rs
@@ -1,0 +1,3 @@
+// @generated
+
+pub mod realtime;

--- a/src/yahoo/mod.rs
+++ b/src/yahoo/mod.rs
@@ -1,5 +1,5 @@
 mod chart;
-pub use chart::{load_daily, load_daily_range, Data};
+pub use chart::{load_daily, load_daily_with_events, load_daily_range, load_daily_range_with_events, Data, Dividend, Split};
 
 mod realtime;
 pub use realtime::{PricingData, PricingData_MarketHoursType};

--- a/src/yahoo/mod.rs
+++ b/src/yahoo/mod.rs
@@ -4,8 +4,8 @@ pub use chart::{
     Dividend, Split,
 };
 
-mod realtime;
-pub use realtime::{PricingData, PricingData_MarketHoursType};
+mod gen;
+pub use gen::realtime::{pricing_data::MarketHoursType, PricingData};
 
 mod web_scraper;
 pub use web_scraper::{scrape, CompanyProfile, QuoteSummaryStore};

--- a/src/yahoo/mod.rs
+++ b/src/yahoo/mod.rs
@@ -1,8 +1,11 @@
 mod chart;
-pub use chart::{load_daily, load_daily_with_events, load_daily_range, load_daily_range_with_events, Data, Dividend, Split};
+pub use chart::{
+    load_daily, load_daily_range, load_daily_range_with_events, load_daily_with_events, Data,
+    Dividend, Split,
+};
 
 mod realtime;
 pub use realtime::{PricingData, PricingData_MarketHoursType};
 
 mod web_scraper;
-pub use web_scraper::{scrape, QuoteSummaryStore, CompanyProfile};
+pub use web_scraper::{scrape, CompanyProfile, QuoteSummaryStore};

--- a/src/yahoo/web_scraper.rs
+++ b/src/yahoo/web_scraper.rs
@@ -58,7 +58,10 @@ pub async fn scrape<'a>(symbol: &'a str) -> Result<Stores> {
 
    // make the call - we do not really expect this to fail.
    // ie - we won't 404 if the symbol doesn't exist
-   let response = reqwest::get(url.clone()).await.context(error::RequestFailed)?;
+   let client = reqwest::ClientBuilder::new()
+        .user_agent("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36")
+        .build().expect("reqwest client");
+   let response = client.get(url.clone()).send().await.context(error::RequestFailed)?;
    ensure!(
       response.status().is_success(),
       error::CallFailed{ url: response.url().to_string(), status: response.status().as_u16() }

--- a/src/yahoo/web_scraper.rs
+++ b/src/yahoo/web_scraper.rs
@@ -1,18 +1,20 @@
 use reqwest::Url;
 use serde::Deserialize;
-use snafu::{ ensure, OptionExt, ResultExt };
+use snafu::{ensure, OptionExt, ResultExt};
 use std::env;
-use std::io::{ BufRead, Cursor };
+use std::io::{BufRead, Cursor};
 
-use crate::{ error, Result };
+use crate::{error, Result};
 
 const DATA_VAR: &'static str = "root.App.main";
 
 const BASE_URL: &'static str = "https://finance.yahoo.com";
 
 ez_serde!(QuoteType {
-   #[serde(rename = "longName")] name: String,
-   #[serde(rename = "quoteType")] kind: String
+    #[serde(rename = "longName")]
+    name: String,
+    #[serde(rename = "quoteType")]
+    kind: String
 });
 
 ez_serde!(CompanyProfile {
@@ -44,42 +46,62 @@ ez_serde!(QuoteSummaryStore {
    #[serde(rename = "summaryProfile")] company_profile: Option<CompanyProfile>,
    #[serde(rename = "quoteType")] quote_type: QuoteType
 });
-ez_serde!(Stores { #[serde(rename = "QuoteSummaryStore")] quote_summary_store: QuoteSummaryStore });
+ez_serde!(Stores {
+    #[serde(rename = "QuoteSummaryStore")]
+    quote_summary_store: QuoteSummaryStore
+});
 ez_serde!(Dispatcher { stores: Stores });
-ez_serde!(Context { dispatcher: Dispatcher });
+ez_serde!(Context {
+    dispatcher: Dispatcher
+});
 ez_serde!(Response { context: Context });
 
 pub async fn scrape<'a>(symbol: &'a str) -> Result<Stores> {
-   // construct the lookup URL - encoding it so we're safe
-   let base = format!("{}/quote/{}", env::var("TEST_URL").unwrap_or(BASE_URL.to_string()), symbol);
+    // construct the lookup URL - encoding it so we're safe
+    let base = format!(
+        "{}/quote/{}",
+        env::var("TEST_URL").unwrap_or(BASE_URL.to_string()),
+        symbol
+    );
 
-   let mut url = Url::parse(base.as_str()).context(error::InternalURL { url: base })?;
-   url.query_pairs_mut().append_pair("p", symbol);
+    let mut url = Url::parse(base.as_str()).context(error::InternalURL { url: base })?;
+    url.query_pairs_mut().append_pair("p", symbol);
 
-   // make the call - we do not really expect this to fail.
-   // ie - we won't 404 if the symbol doesn't exist
-   let client = reqwest::ClientBuilder::new()
+    // make the call - we do not really expect this to fail.
+    // ie - we won't 404 if the symbol doesn't exist
+    let client = reqwest::ClientBuilder::new()
         .user_agent("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36")
         .build().expect("reqwest client");
-   let response = client.get(url.clone()).send().await.context(error::RequestFailed)?;
-   ensure!(
-      response.status().is_success(),
-      error::CallFailed{ url: response.url().to_string(), status: response.status().as_u16() }
-   );
+    let response = client
+        .get(url.clone())
+        .send()
+        .await
+        .context(error::RequestFailed)?;
+    ensure!(
+        response.status().is_success(),
+        error::CallFailed {
+            url: response.url().to_string(),
+            status: response.status().as_u16()
+        }
+    );
 
-   let line = Cursor::new(response.text().await.context(error::UnexpectedErrorRead { url: url.clone().to_string() })?)
-      .lines()
-      .map(|line| line.unwrap())
-      .filter(|line| line.trim().starts_with(DATA_VAR))
-      .next()
-      .context(error::MissingData { reason: "no quote data" })?;
-   
-   let data = line
-      .trim()
-      .trim_start_matches(DATA_VAR)
-      .trim_start_matches(|c| c == ' ' || c == '=')
-      .trim_end_matches(';');
+    let line = Cursor::new(response.text().await.context(error::UnexpectedErrorRead {
+        url: url.clone().to_string(),
+    })?)
+    .lines()
+    .map(|line| line.unwrap())
+    .filter(|line| line.trim().starts_with(DATA_VAR))
+    .next()
+    .context(error::MissingData {
+        reason: "no quote data",
+    })?;
 
-   let response = serde_json::from_str::<Response>(data).context(error::BadData)?;
-   Ok(response.context.dispatcher.stores)
+    let data = line
+        .trim()
+        .trim_start_matches(DATA_VAR)
+        .trim_start_matches(|c| c == ' ' || c == '=')
+        .trim_end_matches(';');
+
+    let response = serde_json::from_str::<Response>(data).context(error::BadData)?;
+    Ok(response.context.dispatcher.stores)
 }

--- a/tests/history.rs
+++ b/tests/history.rs
@@ -7,122 +7,159 @@ use tokio_test::block_on;
 use yahoo_finance::{history, Interval};
 
 fn base_mock(test_name: &str, symbol: &str, query: &str) -> std::io::Result<Mock> {
-   // Tell the actual code to use a test URL rather than the live one
-   env::set_var("TEST_URL", mockito::server_url());
+    // Tell the actual code to use a test URL rather than the live one
+    env::set_var("TEST_URL", mockito::server_url());
 
-   // Load the simulated Yahoo data we want to test against
-   let mut file = File::open(format!("tests/history_data/{}.json", test_name))?;
-   let mut contents = String::new();
-   file.read_to_string(&mut contents)?;
+    // Load the simulated Yahoo data we want to test against
+    let mut file = File::open(format!("tests/history_data/{}.json", test_name))?;
+    let mut contents = String::new();
+    file.read_to_string(&mut contents)?;
 
-   // Serve up the test data on the test URL
-   Ok(mock("GET", format!("/{symbol}?{query}", symbol=symbol, query=query).as_str())
-      .with_header("content-type", "application/json")
-      .with_body(&contents)
-      .with_status(200))
+    // Serve up the test data on the test URL
+    Ok(mock(
+        "GET",
+        format!("/{symbol}?{query}", symbol = symbol, query = query).as_str(),
+    )
+    .with_header("content-type", "application/json")
+    .with_body(&contents)
+    .with_status(200))
 }
 
-fn build_interval(interval: Interval) -> String { format!("range={r}&interval={i}", r=interval, i=Interval::_1d) }
+fn build_interval(interval: Interval) -> String {
+    format!("range={r}&interval={i}", r = interval, i = Interval::_1d)
+}
 
 #[test]
 fn retrieve_valid() {
-   //! Ensure that we can load for valid companies
+    //! Ensure that we can load for valid companies
 
-   // GIVEN - a valid response and stock symbol
-   let symbol = "AAPL";
-   let _m = base_mock("aapl", symbol, build_interval(Interval::_6mo).as_str()).unwrap().create();
+    // GIVEN - a valid response and stock symbol
+    let symbol = "AAPL";
+    let _m = base_mock("aapl", symbol, build_interval(Interval::_6mo).as_str())
+        .unwrap()
+        .create();
 
-   // WHEN - we load the data
-   let result = block_on(history::retrieve(symbol)).unwrap();
-   assert!(result.len() > 0)
+    // WHEN - we load the data
+    let result = block_on(history::retrieve(symbol)).unwrap();
+    assert!(result.len() > 0)
 }
 
 #[test]
 #[should_panic(expected = "code: \"Not Found\"")]
 fn retrieve_invalid_symbol() {
-   //! Ensure that we gracefully fail when retrieving data for an invalid symbol
+    //! Ensure that we gracefully fail when retrieving data for an invalid symbol
 
-   // GIVEN - a valid response for an invalid symbol
-   let symbol = "FUBAR";
-   let _m = base_mock("not_found", symbol, build_interval(Interval::_6mo).as_str()).unwrap().create();
+    // GIVEN - a valid response for an invalid symbol
+    let symbol = "FUBAR";
+    let _m = base_mock("not_found", symbol, build_interval(Interval::_6mo).as_str())
+        .unwrap()
+        .create();
 
-   // WHEN - we load the data
-   block_on(history::retrieve(symbol)).unwrap();
+    // WHEN - we load the data
+    block_on(history::retrieve(symbol)).unwrap();
 
-   // THEN - we get an error
+    // THEN - we get an error
 }
 
 #[test]
 #[should_panic(expected = "NoIntraday")]
 fn retrieve_interval_invalid() {
-   //! Ensure that we gracefully fail when we use an intraday interval
+    //! Ensure that we gracefully fail when we use an intraday interval
 
-   // GIVEN - a valid response for an valid symbol
-   let symbol = "AAPL";
-   let _m = base_mock("aapl", symbol, build_interval(Interval::_6mo).as_str()).unwrap().create();
+    // GIVEN - a valid response for an valid symbol
+    let symbol = "AAPL";
+    let _m = base_mock("aapl", symbol, build_interval(Interval::_6mo).as_str())
+        .unwrap()
+        .create();
 
-   // WHEN - we get a date range where the start date is after the end date
-   block_on(history::retrieve_interval(symbol, Interval::_1m)).unwrap();
+    // WHEN - we get a date range where the start date is after the end date
+    block_on(history::retrieve_interval(symbol, Interval::_1m)).unwrap();
 
-   // THEN - we get an error
+    // THEN - we get an error
 }
 
 #[test]
 #[should_panic(expected = "InvalidStartDate")]
 fn retrieve_range_invalid1() {
-   //! Ensure that we gracefully fail when we use no end date before the start date
+    //! Ensure that we gracefully fail when we use no end date before the start date
 
-   // GIVEN - a valid response for an valid symbol
-   let symbol = "AAPL";
-   let _m = base_mock("aapl", symbol, build_interval(Interval::_6mo).as_str()).unwrap().create();
+    // GIVEN - a valid response for an valid symbol
+    let symbol = "AAPL";
+    let _m = base_mock("aapl", symbol, build_interval(Interval::_6mo).as_str())
+        .unwrap()
+        .create();
 
-   // WHEN - we get a date range where the start date is after the end date
-   block_on(history::retrieve_range(symbol, Utc::now() - Duration::days(10), Some(Utc::now() - Duration::days(15)))).unwrap();
+    // WHEN - we get a date range where the start date is after the end date
+    block_on(history::retrieve_range(
+        symbol,
+        Utc::now() - Duration::days(10),
+        Some(Utc::now() - Duration::days(15)),
+    ))
+    .unwrap();
 
-   // THEN - we get an error
+    // THEN - we get an error
 }
 
 #[test]
 #[should_panic(expected = "InvalidStartDate")]
 fn retrieve_range_invalid2() {
-   //! Ensure that we gracefully fail when we use no end date and a start date in the future
+    //! Ensure that we gracefully fail when we use no end date and a start date in the future
 
-   // GIVEN - a valid response for an valid symbol
-   let symbol = "AAPL";
-   let _m = base_mock("aapl", symbol, build_interval(Interval::_6mo).as_str()).unwrap().create();
+    // GIVEN - a valid response for an valid symbol
+    let symbol = "AAPL";
+    let _m = base_mock("aapl", symbol, build_interval(Interval::_6mo).as_str())
+        .unwrap()
+        .create();
 
-   // WHEN - we get a date range where the start date is after the end date
-   block_on(history::retrieve_range(symbol, Utc::now() + Duration::days(10), None)).unwrap();
+    // WHEN - we get a date range where the start date is after the end date
+    block_on(history::retrieve_range(
+        symbol,
+        Utc::now() + Duration::days(10),
+        None,
+    ))
+    .unwrap();
 
-   // THEN - we get an error
+    // THEN - we get an error
 }
 
 #[test]
 fn retrieve_no_quote_data() {
-   //! Ensure that we gracefully handle the case where Yahoo send us an empty dictionary
-   //! of quote data
+    //! Ensure that we gracefully handle the case where Yahoo send us an empty dictionary
+    //! of quote data
 
-   // GIVEN - a valid response with no timestmap & no quote data
-   let symbol = "AAPL";
-   let _m = base_mock("no_quote_data", symbol, build_interval(Interval::_6mo).as_str()).unwrap().create();
+    // GIVEN - a valid response with no timestmap & no quote data
+    let symbol = "AAPL";
+    let _m = base_mock(
+        "no_quote_data",
+        symbol,
+        build_interval(Interval::_6mo).as_str(),
+    )
+    .unwrap()
+    .create();
 
-   // WHEN - we get data where the there is basically no data
-   let result = block_on(history::retrieve(symbol)).unwrap();
-   assert!(result.len() == 0)
+    // WHEN - we get data where the there is basically no data
+    let result = block_on(history::retrieve(symbol)).unwrap();
+    assert!(result.len() == 0)
 }
 
 #[test]
 #[should_panic(expected = "no timestamps")]
 fn retrieve_no_timestamp_data() {
-   //! Ensure that we gracefully handle the case where Yahoo send us an empty dictionary
-   //! of quote data
+    //! Ensure that we gracefully handle the case where Yahoo send us an empty dictionary
+    //! of quote data
 
-   // GIVEN - a valid response with an empty dictionary of quote data and no timestamps
-   let symbol = "AAPL";
-   let _m = base_mock("no_timestamp_data", symbol, build_interval(Interval::_6mo).as_str()).unwrap().create();
+    // GIVEN - a valid response with an empty dictionary of quote data and no timestamps
+    let symbol = "AAPL";
+    let _m = base_mock(
+        "no_timestamp_data",
+        symbol,
+        build_interval(Interval::_6mo).as_str(),
+    )
+    .unwrap()
+    .create();
 
-   // WHEN - we get data where the there are no quotes
-   block_on(history::retrieve(symbol)).unwrap();
+    // WHEN - we get data where the there are no quotes
+    block_on(history::retrieve(symbol)).unwrap();
 
-   // THEN - we get an error
+    // THEN - we get an error
 }

--- a/tests/profile.rs
+++ b/tests/profile.rs
@@ -3,113 +3,114 @@ use std::env;
 use std::fs::File;
 use std::io::prelude::*;
 use tokio_test::block_on;
-use yahoo_finance::{Profile};
+use yahoo_finance::Profile;
 
 fn base_mock(test_name: &str, symbol: &str) -> std::io::Result<Mock> {
-   // Tell the actual code to use a test URL rather than the live one
-   env::set_var("TEST_URL", mockito::server_url());
+    // Tell the actual code to use a test URL rather than the live one
+    env::set_var("TEST_URL", mockito::server_url());
 
-   // Load the simulated Yahoo data we want to test against
-   let mut file = File::open(format!("tests/profile_data/{}.html", test_name))?;
-   let mut contents = String::new();
-   file.read_to_string(&mut contents)?;
+    // Load the simulated Yahoo data we want to test against
+    let mut file = File::open(format!("tests/profile_data/{}.html", test_name))?;
+    let mut contents = String::new();
+    file.read_to_string(&mut contents)?;
 
-   // Serve up the test data on the test URL
-   Ok(mock("GET", format!("/quote/{symbol}?p={symbol}", symbol=symbol).as_str())
-      .with_header("content-type", "text/html")
-      .with_body(&contents)
-      .with_status(200))
+    // Serve up the test data on the test URL
+    Ok(mock(
+        "GET",
+        format!("/quote/{symbol}?p={symbol}", symbol = symbol).as_str(),
+    )
+    .with_header("content-type", "text/html")
+    .with_body(&contents)
+    .with_status(200))
 }
 
 #[test]
 fn load_company() {
-   //! Ensure that we can load for valid companies
+    //! Ensure that we can load for valid companies
 
-   // GIVEN - a valid response and stock symbol
-   let symbol = "AAPL";
-   let _m = base_mock("aapl", symbol).unwrap().create();
+    // GIVEN - a valid response and stock symbol
+    let symbol = "AAPL";
+    let _m = base_mock("aapl", symbol).unwrap().create();
 
-   // WHEN - we load the data
-   let result = block_on(Profile::load(symbol)).unwrap();
+    // WHEN - we load the data
+    let result = block_on(Profile::load(symbol)).unwrap();
 
-   // THEN - we get the results we expect
-   match result {
-      Profile::Company(profile) => {
-         assert_eq!("Apple Inc.", profile.name);
-         // assert_eq!("Consumer Electronics", result.industry);
-         // assert_eq!("Technology", result.sector);
-         // assert_eq!("http://www.apple.com", result.website);
-      },
-      _ => panic!("Needs to be a company profile")
-   }
+    // THEN - we get the results we expect
+    match result {
+        Profile::Company(profile) => {
+            assert_eq!("Apple Inc.", profile.name);
+            // assert_eq!("Consumer Electronics", result.industry);
+            // assert_eq!("Technology", result.sector);
+            // assert_eq!("http://www.apple.com", result.website);
+        }
+        _ => panic!("Needs to be a company profile"),
+    }
 }
 
 #[test]
 fn load_fund() {
-   //! Ensure that we can load for valid funds
+    //! Ensure that we can load for valid funds
 
-   // GIVEN - a valid response and stock symbol
-   let symbol = "QQQ";
-   let _m = base_mock("qqq", symbol).unwrap().create();
+    // GIVEN - a valid response and stock symbol
+    let symbol = "QQQ";
+    let _m = base_mock("qqq", symbol).unwrap().create();
 
-   // WHEN - we load the data
-   let result = block_on(Profile::load(symbol)).unwrap();
+    // WHEN - we load the data
+    let result = block_on(Profile::load(symbol)).unwrap();
 
-   // THEN - we get the results we expect
-   match result {
-      Profile::Fund(profile) => {
-         assert_eq!("Invesco QQQ Trust", profile.name);
-         // assert_eq!("Consumer Electronics", result.industry);
-         // assert_eq!("Technology", result.sector);
-         // assert_eq!("http://www.apple.com", result.website);
-      },
-      _ => panic!("Needs to be a fund  profile")
-   }
+    // THEN - we get the results we expect
+    match result {
+        Profile::Fund(profile) => {
+            assert_eq!("Invesco QQQ Trust", profile.name);
+            // assert_eq!("Consumer Electronics", result.industry);
+            // assert_eq!("Technology", result.sector);
+            // assert_eq!("http://www.apple.com", result.website);
+        }
+        _ => panic!("Needs to be a fund  profile"),
+    }
 }
 
 #[test]
 #[should_panic(expected = "BadData")]
 fn load_bad_data() {
-   //! Ensures that we gracefully fail when Yahoo! sends back bad JSON
+    //! Ensures that we gracefully fail when Yahoo! sends back bad JSON
 
-   // GIVEN - a response that has no data
-   let symbol = "NULL";
-   let _m = base_mock("invalid_json", symbol).unwrap().create();
+    // GIVEN - a response that has no data
+    let symbol = "NULL";
+    let _m = base_mock("invalid_json", symbol).unwrap().create();
 
-   // WHEN - we load the data
-   block_on(Profile::load(symbol)).expect("failure");
+    // WHEN - we load the data
+    block_on(Profile::load(symbol)).expect("failure");
 
-   // THEN - we get an error
+    // THEN - we get an error
 }
 
 #[test]
 #[should_panic(expected = "CallFailed")]
 fn load_bad_response() {
-   //! Ensures that we gracefully fail when Yahoo returns an unexpected return code for a symbol
+    //! Ensures that we gracefully fail when Yahoo returns an unexpected return code for a symbol
 
-   // GIVEN - a symbol that does not exist
-   let symbol = "NULL";
-   let _m = base_mock("aapl", symbol).unwrap()
-      .with_status(404)
-      .create();
+    // GIVEN - a symbol that does not exist
+    let symbol = "NULL";
+    let _m = base_mock("aapl", symbol).unwrap().with_status(404).create();
 
-   // WHEN - we load the data
-   block_on(Profile::load(symbol)).expect("failure");
+    // WHEN - we load the data
+    block_on(Profile::load(symbol)).expect("failure");
 
-   // THEN - we get an error
+    // THEN - we get an error
 }
 
 #[test]
 #[should_panic(expected = "MissingData")]
 fn load_missing_data() {
-   //! Ensures that we gracefully fail when Yahoo! doesn't return the data we expect
+    //! Ensures that we gracefully fail when Yahoo! doesn't return the data we expect
 
-   // GIVEN - a response that has no data
-   let symbol = "NULL";
-   let _m = base_mock("missing_data", symbol).unwrap().create();
+    // GIVEN - a response that has no data
+    let symbol = "NULL";
+    let _m = base_mock("missing_data", symbol).unwrap().create();
 
-   // WHEN - we load the data
-   block_on(Profile::load(symbol)).expect("failure");
+    // WHEN - we load the data
+    block_on(Profile::load(symbol)).expect("failure");
 
-   // THEN - we get an error
+    // THEN - we get an error
 }


### PR DESCRIPTION
This is a simple PR to add support for querying for corporate action events.
* Adds `Dividend` and `Split` types
* Adds `*_with_events()` versions of functions in the `history` API,
which return, along with `Bar` data, any `Dividend` or `Split` actions
in the applicable period.

The current implementation aimed to be minimal, and as such:
* Newly introduced types `Dividend` and `Split` are defined in mod `yahoo`, as opposed to in dependency `market-finance-rs` where types such as `Bar` are defined.
* Implements `Timestamped` for these types, but not other common impls such as `{Partial,}{Ord,Eq}`
* To avoid changing existing signatures, new functions such as `retrieve_with_events` are introduced
* There is no granularity to which events are requested; either they are not requested or both dividends and splits are requested. It may be preferable to allow specifying these.
* Similarly, return sets are simple tuples `(Vec<Bar>, Vec<Dividend>, Vec<Split>)`; a descriptive return `struct` may be preferable.
* Does not concern itself with earnings, as I did not have need/examples of querying such data although I see it as queryable in the API (`events=div|split|earn`).
